### PR TITLE
fix: K8s 워커 노드 서브넷 이동 (#7)

### DIFF
--- a/terraform/environments/prod/compute.tf
+++ b/terraform/environments/prod/compute.tf
@@ -47,7 +47,7 @@ module "k8s_worker_nodes" {
 
   name_prefix = "${var.project}-${var.environment}-k8s-worker"
   network     = module.vpc.vpc_self_link
-  subnetwork  = module.vpc.subnets["web"].self_link
+  subnetwork  = module.vpc.subnets["app"].self_link
 
   # 관리형 인스턴스 그룹 설정
   create_instance_template = true


### PR DESCRIPTION
## 📌 작업한 내용
- K8s 워커 노드 서브넷 배치 문제를 수정하여 올바른 서브넷으로 이동시킴.

## 🔍 참고 사항
- Issue #7 관련 워커 노드 구성 오류를 해결함.
- 서브넷 설정 변경으로 K8s 클러스터 네트워크 안정성 개선.
- 배포 후 클러스터 상태 및 네트워크 연결 확인 필요.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#7

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인