### PR TITLE
chore: GCP 레지스트리 이미지 이름 수정

### DIFF
--- a/k8s-argocd/applications/prod/backend.yaml
+++ b/k8s-argocd/applications/prod/backend.yaml
@@ -21,7 +21,7 @@ metadata:
   # 어노테이션 메타데이터
   annotations:
     # ArgoCD Image Updater 설정
-    argocd-image-updater.argoproj.io/image-list: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-be
+    argocd-image-updater.argoproj.io/image-list: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-be/pinhouse-server
     argocd-image-updater.argoproj.io/backend.update-strategy: newest-build
     argocd-image-updater.argoproj.io/backend.allow-tags: regexp:^[0-9]{8}_[0-9]{6}-[a-f0-9]{7}$
     argocd-image-updater.argoproj.io/backend.kustomize.image-name: REPLACE_ME

--- a/k8s-argocd/applications/prod/frontend.yaml
+++ b/k8s-argocd/applications/prod/frontend.yaml
@@ -22,7 +22,7 @@ metadata:
   # 어노테이션 메타데이터
   annotations:
     # ArgoCD Image Updater 설정
-    argocd-image-updater.argoproj.io/image-list: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-fe
+    argocd-image-updater.argoproj.io/image-list: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-fe/pinhouse-web
     argocd-image-updater.argoproj.io/frontend.update-strategy: newest-build
     argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^[0-9]{8}_[0-9]{6}-[a-f0-9]{7}$
     argocd-image-updater.argoproj.io/frontend.kustomize.image-name: REPLACE_ME


### PR DESCRIPTION
## 📌 작업한 내용
- GCP Artifact Registry에 맞도록 이미지 이름 규칙을 수정.
- 배포 파이프라인에서 참조하는 이미지 경로를 정리하여 푸시 및 배포 일관성 확보.

## 🔍 참고 사항
- Artifact Registry는 저장소, 패키지, 태그 규칙에 맞는 이미지 이름을 사용해야 합니다.
- 이미지 태그는 한 버전만 가리키므로 배포 시 참조 경로 일치 여부를 확인해야 합니다.
- 변경 후에는 빌드된 이미지와 배포 매니페스트의 이미지 이름이 동일한지 검증이 필요합니다.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#12

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인