### PR TITLE
fix: GCP 레지스트리 이미지 Kustomize 반영 누락

### DIFF
--- a/k8s-kustomize/overlays/prod/backend/kustomization.yaml
+++ b/k8s-kustomize/overlays/prod/backend/kustomization.yaml
@@ -14,7 +14,7 @@ nameSuffix: -prod
 # ArgoCD Image Updater가 자동으로 newTag를 업데이트
 images:
   - name: REPLACE_ME
-    newName: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-be
+    newName: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-be/pinhouse-server
     newTag: latest
 
 # overlays 수정내용 반영

--- a/k8s-kustomize/overlays/prod/frontend/kustomization.yaml
+++ b/k8s-kustomize/overlays/prod/frontend/kustomization.yaml
@@ -14,7 +14,7 @@ nameSuffix: -prod
 # ArgoCD Image Updater가 자동으로 newTag를 업데이트
 images:
   - name: REPLACE_ME
-    newName: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-fe
+    newName: asia-northeast3-docker.pkg.dev/prod-pinhouse/pinhouse-prod-fe/pinhouse-web
     newTag: latest
 
 # overlays 수정내용 반영


### PR DESCRIPTION
## 📌 작업한 내용
- Kustomize kustomization.yaml에서 GCP Artifact Registry 이미지 경로를 반영.
- 이미지 참조 누락으로 인한 배포 실패 문제를 해결.

## 🔍 참고 사항
- Kustomize의 images 필드에서 name:newName:newTag 형식으로 이미지 오버라이드를 지정해야 합니다.
- GCP Artifact Registry 형식은 LOCATION-docker.pkg.dev/PROJECT/REPO/IMAGE:TAG 구조를 정확히 맞춰야 합니다.
- 변경 후 kustomize build 명령어로 생성된 YAML에서 이미지 경로를 검증해야 합니다.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#12

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인