### PR TITLE
chore: 템플릿 변경 시 기존 인스턴스 보호

### DIFF
--- a/terraform/environments/prod/compute.tf
+++ b/terraform/environments/prod/compute.tf
@@ -17,6 +17,7 @@ module "k8s_master_nodes" {
 
   # 마스터 노드는 단일 인스턴스로 고정 운영합니다.
   enable_autoscaling = false
+  update_policy_type = "OPPORTUNISTIC"
 
   # 공통 인스턴스 설정
   machine_type       = var.k8s_master_machine_type
@@ -62,11 +63,12 @@ module "k8s_worker_nodes" {
   instance_group_zone        = "${var.region}-a"
   instance_group_target_size = var.k8s_worker_instance_group_size
 
-  # 워커 노드는 비용 절감을 우선하되 필요 시에만 오토스케일링합니다.
-  enable_autoscaling       = var.enable_autoscaling
+  # target_size가 0이면 워커 MIG를 완전히 비워둘 수 있도록 오토스케일러를 비활성화합니다.
+  enable_autoscaling       = var.k8s_worker_instance_group_size > 0 ? var.enable_autoscaling : false
   autoscaling_min_replicas = var.autoscaling_min_replicas
   autoscaling_max_replicas = var.autoscaling_max_replicas
   autoscaling_cpu_target   = 0.7
+  update_policy_type       = "OPPORTUNISTIC"
 
   # 공통 인스턴스 설정
   machine_type       = var.k8s_worker_machine_type


### PR DESCRIPTION
## 📌 작업한 내용
- 인스턴스 템플릿을 수정해도 기존 실행 중인 인스턴스가 영향을 받지 않도록 로직 개선.
- Terraform 또는 GCE Managed Instance Group의 템플릿 업데이트 동작을 제어.

## 🔍 참고 사항
- GCP GCE Managed Instance Group에서 템플릿 변경 시 update-policy의 type을 OPPORTUNISTIC으로 설정하면 새로운 인스턴스에만 적용됩니다.
- 기존 인스턴스는 rolling replacement 대신 유지되며, 최소 가용성 보장과 함께 점진적 업데이트가 가능합니다.
- 배포 후 기존 인스턴스 상태와 새 인스턴스 생성을 모니터링하여 안정성 검증이 필요합니다.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#12

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Kubernetes 마스터 노드의 업데이트 정책 설정을 추가했습니다.
  * 워커 노드의 자동 스케일링 로직을 개선하여 인스턴스 그룹 크기에 따라 자동 스케일링을 조건부로 제어하도록 변경했습니다.
  * Kubernetes 워커 노드의 업데이트 정책 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->