### PR TITLE
fix: 지원하지 않는 taint-controller 설정 삭제

### DIFF
--- a/k8s-kustomize/platform/gce-pd-csi-driver/remove-cloud-sa.yaml
+++ b/k8s-kustomize/platform/gce-pd-csi-driver/remove-cloud-sa.yaml
@@ -1,10 +1,8 @@
 # ========================================
-# JSON Patch - taint-controller의 cloud-sa 설정 제거
+# JSON Patch - taint-controller 컨테이너 제거
 # ========================================
-# noauth 방식에서는 VM 메타데이터 서버를 통해 인증하므로
-# GOOGLE_APPLICATION_CREDENTIALS와 cloud-sa-volume이 불필요
+# v1.17.4에서는 --run-taint-controller 플래그가 지원되지 않음
+# taint-controller 기능은 선택적이므로 제거해도 무방
 
 - op: remove
-  path: /spec/template/spec/containers/5/env
-- op: remove
-  path: /spec/template/spec/containers/5/volumeMounts
+  path: /spec/template/spec/containers/5


### PR DESCRIPTION
## 📌 작업한 내용
- Self-managed K8s에서 지원하지 않는 taint-controller 관련 설정 삭제.
- 노드 스케줄링 및 Pod 배치 오류 해결.

## 🔍 참고 사항
- `TaintController`는 GKE Autopilot에서만 사용되는 기능으로, Self-managed K8s에서는 존재하지 않습니다.
- taint 기반 노드 선택은 수동으로 `kubectl taint` 명령어나 노드 레이블로 대체해야 합니다.
- 삭제 후 Pod 스케줄링 상태와 노드 taint 목록(`kubectl describe node`) 확인 필요합니다.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#35

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GCE PD CSI 드라이버 Kubernetes 배포 설정 업데이트로 v1.17.4와의 호환성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->