### PR TITLE
chore: 모니터링 최소 리소스 최적화 및 빈 map 적용

### DIFF
--- a/k8s-helm/releases/monitoring-core/values-prod-gitops.yaml
+++ b/k8s-helm/releases/monitoring-core/values-prod-gitops.yaml
@@ -75,45 +75,20 @@ kube-prometheus-stack:
 
   alertmanager:
     # Alertmanager는 알림 라우팅 전용이라 상대적으로 작은 리소스로 시작합니다.
-    alertmanagerSpec:
-      # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-      # resources:
-      #   requests:
-      #     cpu: 50m
-      #     memory: 96Mi
-      #   limits:
-      #     cpu: 150m
-      #     memory: 192Mi
+    # 비어 있는 map을 유지해 차트 기본값과 타입 충돌이 나지 않도록 합니다.
+    alertmanagerSpec: {}
 
   prometheusOperator:
     # Operator는 scrape 주체는 아니지만 Prometheus/Alertmanager 리소스를 생성하므로 계속 필요합니다.
-    # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-    # resources:
-    #   requests:
-    #     cpu: 50m
-    #     memory: 96Mi
-    #   limits:
-    #     cpu: 150m
-    #     memory: 192Mi
+    # 비어 있는 map을 유지해 차트 기본값을 그대로 사용합니다.
+    resources: {}
 
   kube-state-metrics:
     # Kubernetes 리소스 상태 수집용 컴포넌트입니다.
-    # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-    # resources:
-    #   requests:
-    #     cpu: 50m
-    #     memory: 192Mi
-    #   limits:
-    #     cpu: 150m
-    #     memory: 384Mi
+    # 비어 있는 map을 유지해 차트 기본값을 그대로 사용합니다.
+    resources: {}
 
   prometheus-node-exporter:
     # 노드 메트릭 수집기라서 가볍게 시작하되 과도한 사용을 막기 위해 제한을 둡니다.
-    # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-    # resources:
-    #   requests:
-    #     cpu: 30m
-    #     memory: 48Mi
-    #   limits:
-    #     cpu: 100m
-    #     memory: 96Mi
+    # 비어 있는 map을 유지해 차트 기본값을 그대로 사용합니다.
+    resources: {}

--- a/k8s-helm/releases/monitoring-core/values.yaml
+++ b/k8s-helm/releases/monitoring-core/values.yaml
@@ -22,15 +22,8 @@ kube-prometheus-stack:
 
   alertmanager:
     enabled: true
-    alertmanagerSpec:
-      # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-      # resources:
-      #   requests:
-      #     cpu: 50m
-      #     memory: 64Mi
-      #   limits:
-      #     cpu: 200m
-      #     memory: 128Mi
+    # 비어 있는 map을 유지해 차트 기본값과 타입 충돌이 나지 않도록 합니다.
+    alertmanagerSpec: {}
 
   grafana:
     enabled: true
@@ -111,31 +104,13 @@ kube-prometheus-stack:
       storageSpec: {}
 
   prometheusOperator:
-    # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-    # resources:
-    #   requests:
-    #     cpu: 50m
-    #     memory: 64Mi
-    #   limits:
-    #     cpu: 200m
-    #     memory: 128Mi
+    # 비어 있는 map을 유지해 차트 기본값을 그대로 사용합니다.
+    resources: {}
 
   kube-state-metrics:
-    # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-    # resources:
-    #   requests:
-    #     cpu: 50m
-    #     memory: 128Mi
-    #   limits:
-    #     cpu: 200m
-    #     memory: 256Mi
+    # 비어 있는 map을 유지해 차트 기본값을 그대로 사용합니다.
+    resources: {}
 
   prometheus-node-exporter:
-    # 리소스 요청/제한은 임시로 주석 처리하고 차트 기본값을 사용합니다.
-    # resources:
-    #   requests:
-    #     cpu: 50m
-    #     memory: 32Mi
-    #   limits:
-    #     cpu: 100m
-    #     memory: 64Mi
+    # 비어 있는 map을 유지해 차트 기본값을 그대로 사용합니다.
+    resources: {}

--- a/k8s-helm/releases/monitoring-loki/values-prod-gitops.yaml
+++ b/k8s-helm/releases/monitoring-loki/values-prod-gitops.yaml
@@ -37,7 +37,15 @@ loki:
     resources:
       requests:
         cpu: 500m
-        memory: 1Gi
+        memory: 512Mi
       limits:
         cpu: 2000m
-        memory: 2Gi
+        memory: 1Gi
+
+  chunksCache:
+    # 차트 값은 MB 단위를 사용하므로 256Mi 수준으로 낮춥니다.
+    allocatedMemory: 256
+
+  resultsCache:
+    # 조회 캐시도 동일하게 256Mi 수준으로 낮춥니다.
+    allocatedMemory: 256


### PR DESCRIPTION
## 📌 작업한 내용
- 모니터링 스택의 최소 requests/limits 용량을 클러스터 규모에 맞게 조정.
- 주석 처리된 resources 설정을 빈 map `{}`으로 변경하여 Helm 렌더링 오류 방지.

## 🔍 참고 사항
- Prometheus/Grafana의 최소 리소스 요구사항을 반영하여 스케줄러 배치 가능하도록 최적화.
- 빈 map `{}`은 Kubernetes에서 기본값을 사용하도록 하며, Helm 템플릿 파싱 오류를 예방합니다.
- 리소스 조정 후 Pod 상태와 메모리/CPU 사용량 모니터링으로 안정성 검증 필요.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#40

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Loki 메모리 리소스 설정을 최적화했습니다. 메모리 요청을 1Gi에서 512Mi로, 제한을 2Gi에서 1Gi로 감소시켰습니다.
  * Loki 캐시 구성을 추가했습니다. 청크 캐시 및 결과 캐시에 대한 메모리 할당 설정을 활성화했습니다.
  * Kubernetes 모니터링 스택 설정을 Helm 차트 기본값과 맞춰 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->