### PR TITLE
chore: 리소스 부족으로 Loki chunksCache 비활성화

### DIFF
--- a/k8s-helm/releases/monitoring-loki/values-prod-gitops.yaml
+++ b/k8s-helm/releases/monitoring-loki/values-prod-gitops.yaml
@@ -43,8 +43,8 @@ loki:
         memory: 1Gi
 
   chunksCache:
-    # 차트 값은 MB 단위를 사용하므로 256Mi 수준으로 낮춥니다.
-    allocatedMemory: 256
+    # 현재 클러스터 규모에서는 chunks cache를 유지할 이점보다 스케줄 비용이 더 큽니다.
+    enabled: false
 
   resultsCache:
     # 조회 캐시도 동일하게 256Mi 수준으로 낮춥니다.


### PR DESCRIPTION
## 📌 작업한 내용
- Loki의 chunksCache 구성 요소를 제거하여 메모리 사용량 감소.
- 클러스터 리소스 부족으로 인한 모니터링 스택 배포 실패 해결.

## 🔍 참고 사항
- Loki chunksCache는 로그 쿼리 성능을 향상시키지만 상당한 메모리를 소비합니다.
- 캐시 비활성화로 로그 저장은 정상 작동하나, 반복 쿼리 성능이 저하될 수 있습니다.
- 리소스 여유 확보 후 캐시 용량을 조정하거나 memcached 대신 파일 기반 캐시로 전환 검토.

## 🖼️ 스크린샷
(해당 사항 없음)

## 🔗 관련 이슈
#40

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Loki 모니터링 시스템의 청크 캐시 구성을 업데이트하여 캐싱 기능을 비활성화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->