### PR TITLE
 fix: Loki 서비스명 및 Alloy relabel 설정 완료 (#49)

### DIFF
--- a/k8s-helm/releases/monitoring-alloy/values.yaml
+++ b/k8s-helm/releases/monitoring-alloy/values.yaml
@@ -140,7 +140,12 @@ alloy:
           }
 
           rule {
-            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            source_labels = ["__meta_kubernetes_pod_label_app"]
+            target_label  = "service"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_app"]
             separator     = "/"
             target_label  = "job"
           }

--- a/k8s-kustomize/base/backend/deployment.yaml
+++ b/k8s-kustomize/base/backend/deployment.yaml
@@ -37,7 +37,9 @@ spec:
           # 수정될 이미지
           image: REPLACE_ME
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+              protocol: TCP
 
           # 파라미터 스토어에서 주입받는 내용
           envFrom:

--- a/k8s-kustomize/base/backend/podmonitor.yaml
+++ b/k8s-kustomize/base/backend/podmonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+
+metadata:
+  name: backend-podmonitor
+  labels:
+    pinhouse.co.kr/scrape-via: "prometheus"  # 필수: Alloy가 인식하는 라벨
+    app: backend
+
+spec:
+  selector:
+    matchLabels:
+      app: backend  # BE Deployment의 Pod 라벨과 일치
+
+  namespaceSelector:
+    matchNames:
+      - app
+
+  podMetricsEndpoints:
+    - port: http  # Deployment의 containerPort 이름
+      path: /actuator/prometheus  # Spring Boot Actuator 메트릭 경로
+      interval: 30s
+      scrapeTimeout: 10s

--- a/k8s-kustomize/base/frontend/deployment.yaml
+++ b/k8s-kustomize/base/frontend/deployment.yaml
@@ -37,4 +37,6 @@ spec:
           # 수정될 이미지
           image: REPLACE_ME
           ports:
-            - containerPort: 3000
+            - name: http
+              containerPort: 3000
+              protocol: TCP

--- a/k8s-kustomize/base/frontend/service.yaml
+++ b/k8s-kustomize/base/frontend/service.yaml
@@ -15,6 +15,7 @@ spec:
 
   # 포트 및 타겟 포트
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
-      targetPort: 3000
+      targetPort: http


### PR DESCRIPTION
## 📌 작업한 내용
- **Loki 서비스명 분류**: 서비스 및 포트 별칭 설정으로 로그 라벨링 정상화
- **Alloy relabel 수정**: Alloy 서비스 로그가 정상 출력되도록 라벨 재설정

## 🔍 참고 사항
- Grafana Loki에서 Service 라벨 정상 분류로 로그 탐색 가능
- Alloy 로그 수집 파이프라인 안정화, `unknown_service` 문제 해결
- `relabel_configs`를 통한 서비스별 로그 구분 및 포트 매핑 적용
- PinHouse_CLOUD 환경의 로그 관찰성 완성

## 🖼️ 스크린샷
- X

## 🔗 관련 이슈
#49 (Grafana Loki Service명 분류 문제)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 업데이트**
  * 백엔드 애플리케이션 모니터링 설정 추가
  * 컨테이너 포트 명시 및 프로토콜 지정
  * 모니터링 및 로깅 구성 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->