### PR TITLE
fix: Tempo URL 및 Alloy config 수정 (#49)

### DIFF
--- a/k8s-helm/releases/monitoring-alloy/values.yaml
+++ b/k8s-helm/releases/monitoring-alloy/values.yaml
@@ -32,6 +32,10 @@ alloy:
 
     configMap:
       content: |-
+        // ========================================
+        // Traces
+        // ========================================
+        // 애플리케이션이 보낸 OTLP 트레이스를 gRPC와 HTTP로 모두 수신합니다.
         otelcol.receiver.otlp "traces" {
           grpc {}
           http {}
@@ -41,12 +45,14 @@ alloy:
           }
         }
 
+        // 수신한 트레이스를 배치로 묶어 Tempo로 전달합니다.
         otelcol.processor.batch "traces" {
           output {
             traces = [otelcol.exporter.otlp.tempo.input]
           }
         }
 
+        // 클러스터 내부 Tempo distributor로 트레이스를 전송합니다.
         otelcol.exporter.otlp "tempo" {
           client {
             endpoint = "monitoring-tempo-distributor.monitoring.svc.cluster.local:4317"
@@ -57,6 +63,10 @@ alloy:
           }
         }
 
+        // ========================================
+        // Metrics
+        // ========================================
+        // Alloy가 수집한 메트릭은 Prometheus remote write receiver로 전달합니다.
         prometheus.remote_write "prometheus" {
           external_labels = {
             cluster     = "{{ .Values.global.clusterName }}",
@@ -68,6 +78,7 @@ alloy:
           }
         }
 
+        // ServiceMonitor 리소스를 읽어 메트릭 대상을 자동으로 수집합니다.
         prometheus.operator.servicemonitors "cluster" {
           forward_to = [prometheus.remote_write.prometheus.receiver]
 
@@ -81,6 +92,7 @@ alloy:
           }
         }
 
+        // PodMonitor 리소스를 읽어 Pod 단위 메트릭 대상을 자동으로 수집합니다.
         prometheus.operator.podmonitors "cluster" {
           forward_to = [prometheus.remote_write.prometheus.receiver]
 
@@ -94,6 +106,7 @@ alloy:
           }
         }
 
+        // Probe 리소스를 읽어 블랙박스 성격의 메트릭 수집 대상을 자동으로 수집합니다.
         prometheus.operator.probes "cluster" {
           forward_to = [prometheus.remote_write.prometheus.receiver]
 
@@ -107,6 +120,10 @@ alloy:
           }
         }
 
+        // ========================================
+        // Logs
+        // ========================================
+        // 각 Alloy Pod는 자신이 올라간 노드의 Pod 로그만 읽도록 범위를 제한합니다.
         discovery.kubernetes "pods_on_same_node" {
           role = "pod"
 
@@ -116,52 +133,99 @@ alloy:
           }
         }
 
+        // Kubernetes 메타데이터를 Loki 조회용 라벨로 정리합니다.
         loki.relabel "pod_logs" {
           forward_to = [loki.process.pod_logs.receiver]
 
+          // 네임스페이스는 가장 기본적인 조회 축이라 그대로 보존합니다.
           rule {
             source_labels = ["__meta_kubernetes_namespace"]
             target_label  = "namespace"
           }
 
+          // Pod 이름을 그대로 라벨로 남겨 개별 인스턴스 추적에 사용합니다.
           rule {
             source_labels = ["__meta_kubernetes_pod_name"]
             target_label  = "pod"
           }
 
+          // 컨테이너 이름은 service fallback과 세부 필터링에 함께 사용합니다.
           rule {
             source_labels = ["__meta_kubernetes_pod_container_name"]
             target_label  = "container"
           }
 
+          // 장애 분석 시 노드 기준 조회가 가능하도록 노드 이름을 남깁니다.
           rule {
             source_labels = ["__meta_kubernetes_pod_node_name"]
             target_label  = "node"
           }
 
+          // service 기본값은 컨테이너 이름으로 두어 앱 라벨이 없는 로그도 조회 가능하게 합니다.
           rule {
-            source_labels = ["__meta_kubernetes_pod_label_app"]
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            regex         = "(.+)"
+            replacement   = "$1"
             target_label  = "service"
           }
 
+          // 현재 애플리케이션 매니페스트가 주로 사용하는 app 라벨이 있으면 service를 앱 이름으로 맞춥니다.
           rule {
-            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_app"]
+            source_labels = ["__meta_kubernetes_pod_label_app"]
+            regex         = "(.+)"
+            replacement   = "$1"
+            target_label  = "service"
+          }
+
+          // 표준 app.kubernetes.io/name 라벨이 있으면 service를 그 값으로 정규화합니다.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex         = "(.+)"
+            replacement   = "$1"
+            target_label  = "service"
+          }
+
+          // service_name은 최종 service 값을 그대로 복사해 Tempo 연동이나 대시보드 변수에 재사용합니다.
+          rule {
+            source_labels = ["service"]
+            regex         = "(.+)"
+            replacement   = "$1"
+            target_label  = "service_name"
+          }
+
+          // job 기본값은 namespace/pod 형식으로 두어 app 라벨이 없는 로그도 식별할 수 있게 합니다.
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
             separator     = "/"
+            regex         = "(.+)/(.+)"
+            replacement   = "$1/$2"
+            target_label  = "job"
+          }
+
+          // service가 정규화됐으면 job도 namespace/service 형식으로 맞춥니다.
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "service"]
+            separator     = "/"
+            regex         = "(.+)/(.+)"
+            replacement   = "$1/$2"
             target_label  = "job"
           }
         }
 
+        // CRI 로그 포맷을 파싱한 뒤 Loki로 전달합니다.
         loki.process "pod_logs" {
           forward_to = [loki.write.default.receiver]
 
           stage.cri {}
         }
 
+        // 현재 노드의 Pod 로그를 읽어 relabel 단계로 넘깁니다.
         loki.source.kubernetes "pods" {
           targets    = discovery.kubernetes.pods_on_same_node.targets
           forward_to = [loki.relabel.pod_logs.receiver]
         }
 
+        // 공통 외부 라벨을 함께 붙여 Loki로 전송합니다.
         loki.write "default" {
           external_labels = {
             cluster     = "{{ .Values.global.clusterName }}",

--- a/k8s-helm/releases/monitoring-core/values.yaml
+++ b/k8s-helm/releases/monitoring-core/values.yaml
@@ -61,7 +61,7 @@ kube-prometheus-stack:
         uid: tempo
         type: tempo
         access: proxy
-        url: http://monitoring-tempo-query-frontend.monitoring.svc.cluster.local:3100
+        url: http://monitoring-tempo-query-frontend.monitoring.svc.cluster.local:3200
         isDefault: false
 
   prometheus:


### PR DESCRIPTION
## 📌 작업한 내용
- **Tempo URL 수정**: Grafana Tempo 트레이싱 엔드포인트 정확한 경로 설정
- **config.alloy 수정**: Alloy 관찰성 파이프라인 구성 업데이트

## 🔍 참고 사항
- Tempo 트레이싱 데이터 수집 정상화 (분산 추적 완료)
- Alloy 설정 최적화: Loki 로그 + Tempo 트레이스 + Prometheus 메트릭 통합
- PinHouse_CLOUD 관찰성 스택 완성 (로그/메트릭/트레이스)
- 전체 APM 체계 구축으로 디버깅 효율성 대폭 향상

## 🖼️ 스크린샷
- X

## 🔗 관련 이슈
#49 (Grafana Loki/Tempo 설정)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] Grafana 대시보드에서 트레이싱 확인
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모니터링 인프라 구성 업데이트: OTLP 트레이스 파이프라인에 gRPC 및 HTTP 지원 추가, 데이터 배치 처리 및 분산 추적 시스템으로의 내보내기 설정
  * 로그 수집 파이프라인의 레이블 지정 규칙 확장으로 서비스 및 작업 식별 개선
  * 분산 추적 조회 엔드포인트 포트 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->