### PR TITLE
fix: Tempo metricsGenerator + Alloy logpods 수집 개선

### DIFF
--- a/k8s-helm/releases/monitoring-alloy/templates/podlogs.yaml
+++ b/k8s-helm/releases/monitoring-alloy/templates/podlogs.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.podLogs.enabled }}
+
+apiVersion: monitoring.grafana.com/v1alpha2
+
+kind: PodLogs
+
+# 메타데이터
+metadata:
+  name: {{ .Release.Name }}-pods
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: monitoring-alloy
+    app.kubernetes.io/component: podlogs
+
+# 스펙. 현재는 모드 파드 수집 진행함.
+spec:
+  namespaceSelector: {}
+  selector: {}
+
+  # 라벨링
+  relabelings:
+    # 네임스페이스는 가장 기본적인 조회 축이라 그대로 보존합니다.
+    - sourceLabels:
+        - __meta_kubernetes_namespace
+      targetLabel: namespace
+
+    # Pod 이름을 그대로 라벨로 남겨 개별 인스턴스 추적에 사용합니다.
+    - sourceLabels:
+        - __meta_kubernetes_pod_name
+      targetLabel: pod
+
+    # 컨테이너 이름은 service fallback과 세부 필터링에 함께 사용합니다.
+    - sourceLabels:
+        - __meta_kubernetes_pod_container_name
+      targetLabel: container
+
+    # 장애 분석 시 노드 기준 조회가 가능하도록 노드 이름을 남깁니다.
+    - sourceLabels:
+        - __meta_kubernetes_pod_node_name
+      targetLabel: node
+
+    # service 추출 규칙: 우선순위가 낮은 것부터 높은 순서로 덮어씁니다.
+
+    # 1. 기본값: 컨테이너 이름
+    - sourceLabels:
+        - __meta_kubernetes_pod_container_name
+      targetLabel: service
+    # 2. Pod controller가 ReplicaSet이면 Deployment 이름 추출
+    - sourceLabels:
+        - __meta_kubernetes_pod_controller_kind
+        - __meta_kubernetes_pod_controller_name
+      separator: /
+      regex: ReplicaSet/(.+)-[a-z0-9]{8,10}$
+      replacement: $1
+      targetLabel: service
+
+    # 3. app 라벨이 있으면 우선 사용
+    - sourceLabels:
+        - __meta_kubernetes_pod_label_app
+      regex: (.+)
+      targetLabel: service
+
+    # 4. 표준 app.kubernetes.io/name 라벨이 있으면 최우선
+    - sourceLabels:
+        - __meta_kubernetes_pod_label_app_kubernetes_io_name
+      regex: (.+)
+      targetLabel: service
+
+    # Logs Drilldown이 우선 참조하는 service_name 라벨도 함께 맞춥니다.
+    - sourceLabels:
+        - service
+      targetLabel: service_name
+
+    # 서비스 네임스페이스는 워크로드 네임스페이스와 동일하게 둡니다.
+    - sourceLabels:
+        - __meta_kubernetes_namespace
+      targetLabel: service_namespace
+
+    # job은 namespace/service 형식으로 설정합니다.
+    - sourceLabels:
+        - __meta_kubernetes_namespace
+        - service
+      separator: /
+      targetLabel: job
+
+{{- end }}

--- a/k8s-helm/releases/monitoring-alloy/values.yaml
+++ b/k8s-helm/releases/monitoring-alloy/values.yaml
@@ -11,6 +11,9 @@ global:
 
 alloy:
   fullnameOverride: monitoring-alloy
+  crds:
+    # PodLogs 같은 Alloy CRD를 릴리스와 함께 명시적으로 설치합니다.
+    create: true
 
   alloy:
     # DaemonSet 여러 인스턴스 간에 scrape 대상을 나눠 가져가도록 클러스터링을 활성화합니다.

--- a/k8s-helm/releases/monitoring-alloy/values.yaml
+++ b/k8s-helm/releases/monitoring-alloy/values.yaml
@@ -18,6 +18,13 @@ alloy:
       enabled: true
 
     enableReporting: false
+    # node_filter가 공식 예시처럼 NODE_NAME 환경변수를 사용할 수 있게 맞춥니다.
+    extraEnv:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+
     extraPorts:
       - name: otlp-grpc
         port: 4317
@@ -113,7 +120,7 @@ alloy:
         // ========================================
         // 각 Alloy Pod는 자신이 올라간 노드의 Pod 로그만 읽도록 범위를 제한합니다.
         loki.source.podlogs "pods" {
-          forward_to = [loki.relabel.pod_logs.receiver]
+          forward_to = [loki.process.pod_logs.receiver]
 
           node_filter {
             enabled = true
@@ -125,75 +132,6 @@ alloy:
           forward_to = [loki.write.default.receiver]
 
           stage.cri {}
-        }
-
-        // Kubernetes 메타데이터를 Loki 조회용 라벨로 정리합니다.
-        loki.relabel "pod_logs" {
-          forward_to = [loki.process.pod_logs.receiver]
-
-          // 네임스페이스는 가장 기본적인 조회 축이라 그대로 보존합니다.
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
-
-          // Pod 이름을 그대로 라벨로 남겨 개별 인스턴스 추적에 사용합니다.
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
-
-          // 컨테이너 이름은 service fallback과 세부 필터링에 함께 사용합니다.
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
-
-          // 장애 분석 시 노드 기준 조회가 가능하도록 노드 이름을 남깁니다.
-          rule {
-            source_labels = ["__meta_kubernetes_pod_node_name"]
-            target_label  = "node"
-          }
-
-          // service 추출 규칙: 우선순위가 낮은 것부터 높은 순서로 덮어씁니다.
-
-          // 1. 기본값: 컨테이너 이름
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "service"
-          }
-
-          // 2. Pod controller가 ReplicaSet이면 Deployment 이름 추출
-          // ReplicaSet 이름 형식: <deployment-name>-<pod-template-hash>
-          // pod-template-hash는 마지막 하이픈 뒤의 8-10자리 영숫자
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
-            separator     = "/"
-            regex         = "ReplicaSet/(.+)-[a-z0-9]{8,10}$"
-            replacement   = "$1"
-            target_label  = "service"
-          }
-
-          // 3. app 라벨이 있으면 우선 사용
-          rule {
-            source_labels = ["__meta_kubernetes_pod_label_app"]
-            regex         = "(.+)"
-            target_label  = "service"
-          }
-
-          // 4. 표준 app.kubernetes.io/name 라벨이 있으면 최우선
-          rule {
-            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-            regex         = "(.+)"
-            target_label  = "service"
-          }
-
-          // job은 namespace/service 형식으로 설정합니다.
-          rule {
-            source_labels = ["__meta_kubernetes_namespace", "service"]
-            separator     = "/"
-            target_label  = "job"
-          }
         }
 
         // 공통 외부 라벨을 함께 붙여 Loki로 전송합니다.
@@ -221,3 +159,11 @@ alloy:
 
   serviceMonitor:
     enabled: true
+
+# ========================================
+# PodLogs 수집 설정
+# ========================================
+
+podLogs:
+  # Alloy loki.source.podlogs가 읽을 PodLogs CR을 함께 배포합니다.
+  enabled: true

--- a/k8s-helm/releases/monitoring-tempo/values-prod-gitops.yaml
+++ b/k8s-helm/releases/monitoring-tempo/values-prod-gitops.yaml
@@ -81,3 +81,20 @@ tempo:
       limits:
         cpu: 500m
         memory: 512Mi
+
+  metricsGenerator:
+    # 트레이스에서 RED 메트릭(Rate, Error, Duration)을 자동 생성합니다.
+    enabled: true
+    replicas: 1
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+    config:
+      # Prometheus로 메트릭을 전송합니다.
+      storage:
+        remote_write:
+          - url: http://monitoring-core-kube-prome-prometheus.monitoring.svc.cluster.local:9090/api/v1/write

--- a/k8s-helm/releases/monitoring-tempo/values-prod-gitops.yaml
+++ b/k8s-helm/releases/monitoring-tempo/values-prod-gitops.yaml
@@ -82,6 +82,13 @@ tempo:
         cpu: 500m
         memory: 512Mi
 
+  overrides:
+    defaults:
+      metrics_generator:
+        # RED 메트릭 생성을 위해 span-metrics processor를 명시적으로 활성화합니다.
+        processors:
+          - span-metrics
+
   metricsGenerator:
     # 트레이스에서 RED 메트릭(Rate, Error, Duration)을 자동 생성합니다.
     enabled: true

--- a/k8s-helm/releases/monitoring-tempo/values.yaml
+++ b/k8s-helm/releases/monitoring-tempo/values.yaml
@@ -43,7 +43,8 @@ tempo:
     replicas: 1
 
   metricsGenerator:
-    enabled: false
+    enabled: true
+    replicas: 1
 
   gateway:
     enabled: false


### PR DESCRIPTION
## 📌 작업한 내용
- **Tempo metricsGenerator 활성화**: 트레이스 데이터에서 메트릭 자동 생성
- **Alloy logpods 기반 수집**: Kubernetes Pod 로그 수집 방식 최적화

## 🔍 참고 사항
- Tempo에서 서비스별 Span 메트릭(RPM, Latency, Error Rate) 자동 생성
- Alloy logpods discovery로 K8s 환경의 모든 Pod 로그 안정적 수집
- Grafana 대시보드에서 실시간 트레이스 메트릭 확인 가능
- PinHouse_CLOUD 관찰성 스택 완전 구축 (로그→메트릭→트레이스)

## 🖼️ 스크린샷

## 🔗 관련 이슈
#49 (Grafana Loki/Tempo 설정 개선)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] Grafana에서 Tempo 메트릭 확인
- [x] Alloy 로그 수집 정상화 확인
- [x] 코드 리뷰 반영 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Pod 로그 수집을 Kubernetes 커스텀 리소스로 조건부 배포 가능 (podLogs 활성화)
  * 분산 추적에서 메트릭 생성기(metricsGenerator) 활성화 및 단일 복제본·자원 설정
* **변경**
  * 로그 파이프라인 재구성: Pod 로그 수집 경로 변경 및 기존 relabel 단계 제거
  * Alloy 관련 배포 설정에 노드 정보(NODE_NAME) 환경변수 주입 및 CRD 생성 옵션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->