### PR TITLE
fix: Tempo local-blocks 추가로 메트릭 출력 활성화 (#49)

### DIFF
--- a/k8s-helm/releases/monitoring-tempo/values-prod-gitops.yaml
+++ b/k8s-helm/releases/monitoring-tempo/values-prod-gitops.yaml
@@ -85,9 +85,10 @@ tempo:
   overrides:
     defaults:
       metrics_generator:
-        # RED 메트릭 생성을 위해 span-metrics processor를 명시적으로 활성화합니다.
+        # RED 메트릭과 TraceQL metrics 생성을 위해 processor를 명시적으로 활성화합니다.
         processors:
           - span-metrics
+          - local-blocks
 
   metricsGenerator:
     # 트레이스에서 RED 메트릭(Rate, Error, Duration)을 자동 생성합니다.
@@ -101,6 +102,10 @@ tempo:
         cpu: 500m
         memory: 1Gi
     config:
+      processor:
+        local_blocks:
+          # TraceQL metrics와 Traces Drilldown이 최근 데이터뿐 아니라 저장소 기준으로도 조회되게 합니다.
+          flush_to_storage: true
       # Prometheus로 메트릭을 전송합니다.
       storage:
         remote_write:


### PR DESCRIPTION
## 📌 작업한 내용
- Tempo 설정에 `local-blocks` 활성화로 메트릭 생성 지원
- 트레이스 데이터에서 자동으로 메트릭 생성 및 Prometheus 연동

## 🔍 참고 사항
- `metrics_generator: {}` 활성화로 Span 메트릭 자동 생성 (RPM, Latency, Error Rate)
- Grafana 대시보드에서 서비스별 트레이스 메트릭 실시간 확인 가능
- Alloy 파이프라인과 연동하여 로그→메트릭→트레이스 완전 통합
- PinHouse_CLOUD 관찰성 완성: Loki 로그 + Tempo 트레이스 + Prometheus 메트릭

## 🖼️ 스크린샷

## 🔗 관련 이슈
#49 (Grafana Loki/Tempo 설정 개선)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] Grafana에서 Tempo 메트릭 생성 확인
- [x] Prometheus 연동 및 쿼리 정상화
- [x] 코드 리뷰 반영 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **Improvements**
  * Tempo 메트릭 생성이 확장되어 추가 메트릭 프로세서가 활성화되었습니다.
  * 로컬 메트릭 데이터가 스토리지에 저장되도록 설정되어 TraceQL 드릴다운 쿼리가 더 포괄적인 데이터를 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->