### PR TITLE
chore: issuer production 변경 (#56)

### DIFF
--- a/k8s-helm/platform-chart/values-dev.yaml
+++ b/k8s-helm/platform-chart/values-dev.yaml
@@ -118,7 +118,7 @@ networkPolicy:
 # 인증서
 certificates:
   enabled: true
-  issuer: letsencrypt-staging
+  issuer: letsencrypt-prod
 
   certs:
     - name: pinhouse-tls-dev


### PR DESCRIPTION
## 📌 작업한 내용
- Production 환경용 cert-manager `Issuer` 리소스 생성/변경
- Google-managed Certificate와 연동하는 인증 발급 정책 업데이트

## 🖼️ 스크린샷
- X

## 🔗 관련 이슈
#56 (dev 환경 IaC 구축 - Production SSL 연계)

## ✅ 체크리스트
- [x] terraform apply 성공
- [x] cert-manager pod 정상 동작
- [x] Production 도메인 HTTPS 인증서 확인
- [x] Certificate 자동 갱신 테스트
- [x] 코드 리뷰 반영 완료