### PR TITLE
chore: 어드민 페이지 클라우드 배포 완료 (#66)

### DIFF
--- a/k8s-argocd/applications/dev/app/admin.yaml
+++ b/k8s-argocd/applications/dev/app/admin.yaml
@@ -1,0 +1,49 @@
+# ===================================
+# Dev Frontend
+# ===================================
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+
+# 기본 정보
+metadata:
+  name: admin-dev
+  namespace: argocd
+  labels:
+    pinhouse.co.kr/environment: dev
+    pinhouse.co.kr/image-updater: enabled
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: frontend=asia-northeast3-docker.pkg.dev/dev-pinhouse/pinhouse-dev-admin/pinhouse-admin
+    argocd-image-updater.argoproj.io/frontend.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^[0-9]{8}_[0-9]{6}-[a-f0-9]{7}$
+    argocd-image-updater.argoproj.io/frontend.kustomize.image-name: REPLACE_ME
+    argocd-image-updater.argoproj.io/write-back-method: git
+    argocd-image-updater.argoproj.io/git-branch: main
+
+    notifications.argoproj.io/subscribe.on-deployed.frontend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.frontend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.frontend-nonprod: ""
+
+spec:
+  project: default
+
+  # Git 저장소에서 관리하는 매니페스트 경로입니다.
+  source:
+    repoURL: https://github.com/PinHouse/PinHouse_CLOUD
+    targetRevision: main
+    path: k8s-kustomize/overlays/dev/admin
+
+  # 배포 대상 클러스터와 네임스페이스입니다.
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: app
+
+  # Git 기준으로 자동 동기화합니다.
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s-kustomize/base/admin/deployment.yaml
+++ b/k8s-kustomize/base/admin/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+
+# 기본 정보
+metadata:
+  name: pinhouse-admin
+
+# 스펙
+spec:
+  replicas: 2
+  # RS 최근 3개 버전만 보관
+  revisionHistoryLimit: 3
+
+  # 배포 전략: Zero-downtime Rolling Update
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0  # 삭제 되는 Pod 수
+      maxSurge: 1        # 업데이트를 위해서 1개의 Pod 추가
+
+  # 셀렉터
+  selector:
+    matchLabels:
+      app: admin
+
+  # 라벨
+  template:
+    metadata:
+      labels:
+        app: admin
+
+    # 컨테이너 스펙
+    spec:
+      containers:
+        - name: pinhouse-admin
+
+          # 수정될 이미지
+          image: REPLACE_ME
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP

--- a/k8s-kustomize/base/admin/kustomization.yaml
+++ b/k8s-kustomize/base/admin/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# 적용될 리소스
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s-kustomize/base/admin/service.yaml
+++ b/k8s-kustomize/base/admin/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+
+# 기본 정보
+metadata:
+  name: admin-service
+
+# 스펙
+spec:
+  type: ClusterIP
+
+  # 라벨 셀렉터
+  selector:
+    app: admin
+
+  # 포트 및 타겟 포트
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http

--- a/k8s-kustomize/overlays/dev/admin/deployment.yaml
+++ b/k8s-kustomize/overlays/dev/admin/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+
+# 기본 설정
+metadata:
+  name: pinhouse-admin
+
+# 스펙
+spec:
+  replicas: 2
+
+  template:
+    metadata:
+      labels:
+        environment: dev
+
+    spec:
+      containers:
+        - name: pinhouse-admin

--- a/k8s-kustomize/overlays/dev/admin/httproute.yaml
+++ b/k8s-kustomize/overlays/dev/admin/httproute.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+
+# 기본 설정
+metadata:
+  name: admin
+
+# 스펙
+spec:
+  parentRefs:
+    - name: pinhouse-gateway
+      namespace: nginx-gateway
+
+  # 도메인 명
+  hostnames:
+    - "admin.dev.pinhouse.co.kr"
+
+  # 참조 규칙
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: admin-service-dev
+          port: 80

--- a/k8s-kustomize/overlays/dev/admin/kustomization.yaml
+++ b/k8s-kustomize/overlays/dev/admin/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# 네임 스페이스
+namespace: app
+
+resources:
+  - ../../../base/admin
+  - httproute.yaml
+
+nameSuffix: -dev
+
+# 이미지 수정
+# ArgoCD Image Updater가 자동으로 newTag를 업데이트
+images:
+  - name: REPLACE_ME
+    newName: asia-northeast3-docker.pkg.dev/dev-pinhouse/pinhouse-dev-admin/pinhouse-admin
+    newTag: latest
+
+# overlays 수정내용 반영
+patches:
+  - path: deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: pinhouse-admin


### PR DESCRIPTION
## 📌 작업한 내용
```
어드민 페이지 배포:
- PinHouse_CLOUD 환경 배포
- 어드민 대시보드 활성화
- BE 연동 확인
```

## 🔍 배포 상세
```
배포 환경:
- 클라우드 서버 배포 완료
- HTTPS/SSL 설정
- BE API 연동 테스트
- 로드밸런싱 적용
```

## 🖼️ 스크린샷
```
배포 확인:
어드민 로그인 화면 | 대시보드 접속 성공
```

## 🔗 관련 이슈
#66 (어드민 페이지 배포)

## ✅ 체크리스트
- [x] 클라우드 배포 완료
- [x] BE 연동 테스트 완료
- [x] 성능/보안 점검 완료
- [x] 코드 리뷰 반영 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 개발 환경에 Admin 애플리케이션 인프라 구성 추가
  * 자동 동기화 및 자가 치유 기능 활성화
  * 이미지 자동 업데이트 기능 설정
  * 무중단 배포를 위한 순차 롤아웃 전략 구성
  * admin.dev.pinhouse.co.kr 도메인을 통한 접근 경로 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->