### PR TITLE
chore: 어드민 페이지 TLS 및 디스코드 알림 설정 수정 (#66)

### DIFF
--- a/k8s-argocd/applications/dev/app/admin.yaml
+++ b/k8s-argocd/applications/dev/app/admin.yaml
@@ -1,5 +1,5 @@
 # ===================================
-# Dev Frontend
+# Dev Admin
 # ===================================
 
 apiVersion: argoproj.io/v1alpha1
@@ -22,9 +22,9 @@ metadata:
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main
 
-    notifications.argoproj.io/subscribe.on-deployed.frontend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-failed.frontend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-health-degraded.frontend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-deployed.admin-nonprod: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.admin-nonprod: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.admin-nonprod: ""
 
 spec:
   project: default

--- a/k8s-helm/platform-chart/templates/nginx-gateway/gateway.yaml
+++ b/k8s-helm/platform-chart/templates/nginx-gateway/gateway.yaml
@@ -82,4 +82,20 @@ spec:
           from: All
     {{- end }}
 
+    {{- if .Values.gateway.listeners.admin.enabled }}
+    # Admin
+    - name: admin-https
+      port: 443
+      protocol: HTTPS
+      hostname: {{ .Values.gateway.listeners.admin.domain }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: {{ .Values.gateway.listeners.admin.tlsSecretName }}
+            namespace: {{ .Values.gateway.namespace }}
+      allowedRoutes:
+        namespaces:
+          from: All
+    {{- end }}
+
 {{- end }}

--- a/k8s-helm/platform-chart/values-dev.yaml
+++ b/k8s-helm/platform-chart/values-dev.yaml
@@ -65,6 +65,11 @@ gateway:
       domain: grafana.dev.pinhouse.co.kr
       tlsSecretName: pinhouse-tls-grafana
 
+    admin:
+      enabled: true
+      domain: admin.dev.pinhouse.co.kr
+      tlsSecretName: pinhouse-tls-admin
+
 # 접근 제어 (Access Control) - 비운영도 운영과 같은 기준으로 차단
 accessControl:
   enabled: true
@@ -162,6 +167,12 @@ certificates:
       namespace: nginx-gateway
       dnsNames:
         - grafana.dev.pinhouse.co.kr
+      enabled: true
+
+    - name: pinhouse-tls-admin
+      namespace: nginx-gateway
+      dnsNames:
+        - admin.dev.pinhouse.co.kr
       enabled: true
 
 # GCP Secret Manager 기반 시크릿 적용

--- a/k8s-helm/platform-chart/values.yaml
+++ b/k8s-helm/platform-chart/values.yaml
@@ -77,6 +77,11 @@ gateway:
       domain: grafana.your-domain.com  # 🔒 실제 도메인으로 변경
       tlsSecretName: your-tls-grafana
 
+    admin:
+      enabled: false
+      domain: admin.your-domain.com  # 🔒 실제 도메인으로 변경
+      tlsSecretName: your-tls-admin
+
 # 접근 제어 (Access Control)
 accessControl:
   enabled: false

--- a/k8s-kustomize/platform/argocd/base/notifications-cm.yaml
+++ b/k8s-kustomize/platform/argocd/base/notifications-cm.yaml
@@ -37,6 +37,13 @@ data:
     - name: Content-Type
       value: application/json
 
+  # Admin Nonprod (Dev + Staging)
+  service.webhook.admin-nonprod: |
+    url: $discord-admin-nonprod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
+
   # Frontend Production
   service.webhook.frontend-prod: |
     url: $discord-frontend-prod-webhook
@@ -95,6 +102,44 @@ data:
             }]
           }
       backend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "ArgoCD 배포가 성공적으로 완료되었습니다.",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{ index .app.metadata.labels "pinhouse.co.kr/environment" | upper }}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "📍 Namespace",
+                  "value": "{{.app.spec.destination.namespace}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔖 Revision",
+                  "value": "{{.app.status.sync.revision | substr 0 7}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
+      admin-nonprod:
         method: POST
         body: |
           {
@@ -364,6 +409,43 @@ data:
               ]
             }]
           }
+      admin-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "ArgoCD 동기화에 실패했습니다.",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{ index .app.metadata.labels "pinhouse.co.kr/environment" | upper }}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "📍 Namespace",
+                  "value": "{{.app.spec.destination.namespace}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ Error",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
       ai-nonprod:
         method: POST
         body: |
@@ -551,6 +633,38 @@ data:
             }]
           }
       backend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "애플리케이션 헬스 상태가 비정상입니다.",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{ index .app.metadata.labels "pinhouse.co.kr/environment" | upper }}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      admin-nonprod:
         method: POST
         body: |
           {

--- a/k8s-kustomize/platform/argocd/secrets/notifications-secret.yaml.example
+++ b/k8s-kustomize/platform/argocd/secrets/notifications-secret.yaml.example
@@ -37,6 +37,9 @@ stringData:
   # Backend Nonprod 환경 Discord Webhook URL (Dev + Staging)
   discord-backend-nonprod-webhook: "YOUR_BACKEND_NONPROD_DISCORD_WEBHOOK_URL_HERE"
 
+  # Admin Nonprod 환경 Discord Webhook URL (Dev + Staging)
+  discord-admin-nonprod-webhook: "YOUR_ADMIN_NONPROD_DISCORD_WEBHOOK_URL_HERE"
+
   # ===================================
   # Prod
   # ===================================
@@ -46,3 +49,6 @@ stringData:
 
   # Backend Production 환경 Discord Webhook URL
   discord-backend-prod-webhook: "YOUR_BACKEND_PROD_DISCORD_WEBHOOK_URL_HERE"
+
+  # Admin Production 환경 Discord Webhook URL
+  discord-admin-prod-webhook: "YOUR_ADMIN_PROD_DISCORD_WEBHOOK_URL_HERE"


### PR DESCRIPTION
## 📌 작업한 내용
```
어드민 페이지 배포:
- PinHouse_CLOUD 환경 배포
- 어드민 대시보드 활성화
- BE 연동 확인
```

## 🔍 배포 상세
```
배포 환경:
- 클라우드 서버 배포 완료
- HTTPS/SSL 설정
- BE API 연동 테스트
- 로드밸런싱 적용
```

## 🖼️ 스크린샷
```
배포 확인:
어드민 로그인 화면 | 대시보드 접속 성공
```

## 🔗 관련 이슈
#66 (어드민 페이지 배포)

## ✅ 체크리스트
- [x] 클라우드 배포 완료
- [x] BE 연동 테스트 완료
- [x] 성능/보안 점검 완료
- [x] 코드 리뷰 반영 완료